### PR TITLE
Update link_images.sh

### DIFF
--- a/link_images.sh
+++ b/link_images.sh
@@ -25,7 +25,7 @@ ln -s test val
 cd ..
 
 rm -f $output/{train,test}/*/*.off
-if [ $3 == 2 ]
+if [[ $3 == 2 ]]
 then
     for ((i=0;i<20;i++))
     do


### PR DESCRIPTION
Line28 condition fails (`link_images.sh: line 28: [: ==: unary operator expected`) when using the suggested command on your multi-view dataset.